### PR TITLE
Add KNode for the Articulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 bitflags = "2.6.0"
 cortex-m = "0.7.7"
+heapless = "0.8.0"
 nalgebra = "0.33.2"
 
 [lib]

--- a/src/articulation.rs
+++ b/src/articulation.rs
@@ -59,16 +59,33 @@ enum Mechanism<T> {
     None,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ArticulationStatus {
+    Idle,
+    Moving,
+    Fault,
+    LimitTriggered,
+    Calibrating,
+    Homed,
+    Offline,
+}
+
+pub enum ArticulationVariant {
+    F32(Articulation<f32>),
+    F64(Articulation<f64>),
+}
+
 /// An articulation represents a 1DOF actuator that will impact the
 /// overall position of a robot.
 #[derive(Debug, Clone, Copy, PartialEq)]
-struct Articulation<T: RealField> {
+pub struct Articulation<T: RealField> {
     id: usize,
     pose: na::Isometry3<T>,
     role: Role,
     mechanism: Mechanism<T>,
     weight: T,
     q: T,
+    status: ArticulationStatus,
 }
 
 impl<T: RealField + PartialOrd + Copy> Articulation<T> {
@@ -89,11 +106,16 @@ impl<T: RealField + PartialOrd + Copy> Articulation<T> {
             weight,
             pose: na::Isometry3::<T>::from_parts(translation, rotation),
             q: T::zero(),
+            status: ArticulationStatus::Idle,
         }
     }
 
     pub fn get_q(&self) -> T {
         return self.q;
+    }
+
+    pub fn get_status(&self) -> ArticulationStatus {
+        self.status
     }
 
     pub fn set_q(&mut self, new_q: T) {

--- a/src/knode.rs
+++ b/src/knode.rs
@@ -1,0 +1,32 @@
+use crate::articulation::{ArticulationStatus, ArticulationVariant};
+use crate::knode_protocol::KNodeMsg;
+use crate::Status;
+use heapless::mpmc::Q8;
+
+/// Description of an Articulation in order to be represented in a Graph
+struct KNode {
+    id: usize,
+    status: Status,
+    art_status: Option<ArticulationStatus>,
+    qin: Q8<KNodeMsg>,
+    qout: Q8<KNodeMsg>,
+}
+
+impl KNode {
+    pub fn new(self, new_id: usize) -> Self {
+        Self {
+            id: new_id,
+            status: Status::Uninitialized,
+            art_status: Option::None,
+            qin: Q8::new(),
+            qout: Q8::new(),
+        }
+    }
+
+    pub fn register_art(&mut self, art: &ArticulationVariant) {
+        match art {
+            ArticulationVariant::F32(a) => self.art_status = Some(a.get_status()),
+            ArticulationVariant::F64(a) => self.art_status = Some(a.get_status()),
+        }
+    }
+}

--- a/src/knode_protocol.rs
+++ b/src/knode_protocol.rs
@@ -1,0 +1,22 @@
+pub struct KNodeMsg {
+    sender: u8,
+    receiver: u8,
+    kind: KNodeMsgKind,
+    payload: KNodePayload,
+}
+
+pub enum KNodeMsgKind {
+    Command(u8),
+    Heartbeat,
+    Err(KNodeErr),
+}
+
+pub enum KNodePayload {
+    Err(KNodeErr),
+    None,
+}
+
+pub enum KNodeErr {
+    WrongState,
+    Fault,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,13 @@
-mod articulation;
+pub mod articulation;
 mod encoder;
+pub mod knode;
 mod stepper;
 
 enum Status {
-    Off,
+    Uninitialized,
     Active,
     Inactive,
-    Error,
+    Error(u32),
 }
 enum Rotation {
     Clk,  // Clockwise
@@ -27,7 +28,7 @@ impl Motor {
     pub fn new(p: u32) -> Self {
         Self {
             power: p,
-            status: Status::Off,
+            status: Status::Uninitialized,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod articulation;
 mod encoder;
 pub mod knode;
+pub mod knode_protocol;
 mod stepper;
 
 enum Status {


### PR DESCRIPTION
The KNode will be the basic node that will represent a kinematic node on a graph, however, it is the interface between the KGraph on an SBC/MainBoard and the Articulation and Controllers themselves.

KNode get information from the other abstractions and send these to the KGraph that has been registered. This allows not only for me to start integrating things early, testing on actual hardware but to have the basis for a distributed articulations within the graph network. Nice.