### PR TITLE
Add KNode protocol logic

### DIFF
--- a/src/articulation.rs
+++ b/src/articulation.rs
@@ -138,7 +138,7 @@ impl<T: RealField + PartialOrd + Copy> Articulation<T> {
 
 #[cfg(test)]
 mod test {
-    use std::f32::consts::PI;
+    use core::f32::consts::PI;
 
     use super::*;
     #[test]

--- a/src/knode.rs
+++ b/src/knode.rs
@@ -1,26 +1,30 @@
 use crate::articulation::{ArticulationStatus, ArticulationVariant};
-use crate::knode_protocol::KNodeMsg;
+use crate::knode_protocol::{KNodeErr, KNodeMsg};
 use crate::Status;
-use heapless::mpmc::Q8;
+use heapless::binary_heap::{BinaryHeap, Max};
 
 /// Description of an Articulation in order to be represented in a Graph
 struct KNode {
     id: usize,
     status: Status,
     art_status: Option<ArticulationStatus>,
-    qin: Q8<KNodeMsg>,
-    qout: Q8<KNodeMsg>,
+    qin: BinaryHeap<KNodeMsg, Max, 8>,
+    qout: BinaryHeap<KNodeMsg, Max, 8>,
 }
 
 impl KNode {
-    pub fn new(self, new_id: usize) -> Self {
+    pub fn new(new_id: usize) -> Self {
         Self {
             id: new_id,
             status: Status::Uninitialized,
             art_status: Option::None,
-            qin: Q8::new(),
-            qout: Q8::new(),
+            qin: BinaryHeap::new(),
+            qout: BinaryHeap::new(),
         }
+    }
+
+    pub fn init(&mut self) {
+        self.status = Status::Active;
     }
 
     pub fn register_art(&mut self, art: &ArticulationVariant) {
@@ -28,5 +32,99 @@ impl KNode {
             ArticulationVariant::F32(a) => self.art_status = Some(a.get_status()),
             ArticulationVariant::F64(a) => self.art_status = Some(a.get_status()),
         }
+    }
+
+    pub fn send(&mut self, msg: KNodeMsg) -> KNodeErr {
+        match &self.qout.push(msg) {
+            Ok(_) => KNodeErr::Ok,
+            Err(_) => KNodeErr::BufferFull,
+        }
+    }
+
+    pub fn read(&mut self) -> Result<KNodeMsg, KNodeErr> {
+        match &self.qin.pop() {
+            Some(msg) => Ok(*msg),
+            None => Err(KNodeErr::BufferFull),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::knode_protocol::{KNodeMsg, KNodeMsgKind};
+
+    fn channel_send_knodemsg(sender: &mut KNode, receiver: &mut KNode) {
+        while let Some(sent_msg) = sender.qout.pop() {
+            receiver.qin.push(sent_msg).unwrap();
+        }
+    }
+
+    #[test]
+    fn send_heartbeat() {
+        let mut sender = KNode::new(1);
+        let mut receiver = KNode::new(2);
+
+        // Fill the sender queue
+        for _ in 0..8 {
+            let msg = KNodeMsg::new(1, 2, KNodeMsgKind::Heartbeat, None);
+            assert_eq!(&sender.send(msg), &KNodeErr::Ok);
+        }
+
+        // Overflow the buffer sending one extra message
+        let msg = KNodeMsg::new(1, 2, KNodeMsgKind::Heartbeat, None);
+        assert_eq!(sender.send(msg), KNodeErr::BufferFull);
+
+        // Send the msgs to the receiver
+        channel_send_knodemsg(&mut sender, &mut receiver);
+
+        // Empty the receiver queue
+        for _ in 0..8 {
+            let msg = KNodeMsg::new(1, 2, KNodeMsgKind::Heartbeat, None);
+            assert_eq!(&receiver.send(msg), &KNodeErr::Ok);
+        }
+    }
+
+    #[test]
+    fn check_msg_priority() {
+        let mut knode = KNode::new(1);
+
+        // TODO: Fix the msg kind to be consistent with the msg payload
+        let msgs: [KNodeMsg; 5] = [
+            KNodeMsg::new(1, 2, KNodeMsgKind::Heartbeat, None),
+            KNodeMsg::new(1, 2, KNodeMsgKind::Command, None),
+            KNodeMsg::new(1, 2, KNodeMsgKind::Debug, None),
+            KNodeMsg::new(1, 2, KNodeMsgKind::Err, None),
+            KNodeMsg::new(1, 2, KNodeMsgKind::Response, None),
+        ];
+
+        for i in 0..5 {
+            let _ = knode.qin.push(msgs[i]);
+        }
+
+        assert_eq!(
+            knode.read().expect("Expected Ok").get_priotiry(),
+            KNodeMsgKind::Err
+        );
+
+        assert_eq!(
+            knode.read().expect("Expected Ok").get_priotiry(),
+            KNodeMsgKind::Heartbeat
+        );
+
+        assert_eq!(
+            knode.read().expect("Expected Ok").get_priotiry(),
+            KNodeMsgKind::Command
+        );
+
+        assert_eq!(
+            knode.read().expect("Expected Ok").get_priotiry(),
+            KNodeMsgKind::Response
+        );
+
+        assert_eq!(
+            knode.read().expect("Expected Ok").get_priotiry(),
+            KNodeMsgKind::Debug
+        );
     }
 }

--- a/src/knode_protocol.rs
+++ b/src/knode_protocol.rs
@@ -1,22 +1,80 @@
+use core::cmp::Ord;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct KNodeMsg {
     sender: u8,
     receiver: u8,
     kind: KNodeMsgKind,
-    payload: KNodePayload,
+    payload: Option<KNodePayload>,
+    priority: u8,
 }
 
+impl KNodeMsg {
+    pub fn new(s: u8, r: u8, k: KNodeMsgKind, p: Option<KNodePayload>) -> Self {
+        Self {
+            sender: s,
+            receiver: r,
+            kind: k,
+            payload: p,
+            priority: 0,
+        }
+    }
+
+    pub fn get_priotiry(&self) -> KNodeMsgKind {
+        self.kind
+    }
+}
+
+impl Ord for KNodeMsg {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.kind.cmp(&other.kind)
+    }
+}
+
+impl PartialOrd for KNodeMsg {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum KNodeMsgKind {
-    Command(u8),
+    Heartbeat = 10,
+    Command = 8,
+    Response = 6,
+    Debug = 2,
+    Err = 255,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub enum KNodePayload {
+    Command(KNodeCommand),
+    Response(KNodeResponse),
     Heartbeat,
     Err(KNodeErr),
+    Info {
+        id: usize,
+        data: [u8; 32],
+        len: usize,
+    },
 }
 
-pub enum KNodePayload {
-    Err(KNodeErr),
-    None,
-}
-
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub enum KNodeErr {
-    WrongState,
-    Fault,
+    InitializationErr,
+    BufferFull,
+    Ok,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub enum KNodeCommand {
+    Initialize,
+    GetData,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
+pub enum KNodeResponse {
+    Initilized,
+    DataSent,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod articulation;
 mod encoder;
 pub mod knode;


### PR DESCRIPTION
The KNode protocol must take into consideration that we need it to be extensible, since the limitations of the system are not yet met and more importantly, the easier to extend, the easier for anyone to use.