### PR TITLE
Add line coverage to the unit testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,11 +25,12 @@ jobs:
     - name: Install embedded target
       run: rustup target add thumbv7em-none-eabihf
 
+    - name: Prepare line coverage
+      run: cargo install cargo-llvm-cov
+
     - name: Build workspace
       run: cargo build --workspace --verbose
 
-    - name: Run tests - Target
-      run: cargo test --workspace --exclude rac-core --verbose
+    - name: Run tests
+      run: cargo llvm-cov --all-features --workspace --verbose
 
-    - name: Run tests - Host
-      run: cargo test --workspace --exclude rac-core --verbose


### PR DESCRIPTION
The unit testing is a bit disorganized and having an actual feedback on how is the status of the codebase is better for the gneeral health of the project.

This commit adds such feature using `cargo-llvm-cov`.